### PR TITLE
Work around apparent Swift issue in Big Sur

### DIFF
--- a/vmcli/Package.swift
+++ b/vmcli/Package.swift
@@ -3,6 +3,16 @@
 
 import PackageDescription
 
+// Add an extra #if checkable symbol on Big Sur, to work around a seeming Swift bug around
+// #available version checks by using `#if EXTRA_WORKAROUND_FOR_BIG_SUR`.
+// See eg https://developer.apple.com/forums/thread/688678 for other bug reports.
+let swiftSettings : [SwiftSetting]
+if #available(macOS 12, *) {
+    swiftSettings = []
+} else {
+    swiftSettings = [ .define("EXTRA_WORKAROUND_FOR_BIG_SUR") ]
+}
+
 let package = Package(
     name: "dealer",
     platforms: [
@@ -15,8 +25,10 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.0"),
     ],
     targets: [
-        .target(name: "vmcli", dependencies: [
-            .product(name: "ArgumentParser", package: "swift-argument-parser"),
-        ]),
+        .target(name: "vmcli",
+                dependencies: [
+                    .product(name: "ArgumentParser", package: "swift-argument-parser"),
+                ],
+                swiftSettings: swiftSettings),
     ]
 )


### PR DESCRIPTION
I'm afraid my previous PR #26 introduced a regression on Big Sur, that I've only just been able to test. If you build `vmcli` on Big Sur and try to execute it, you get
```
dyld: Symbol not found: _OBJC_CLASS_$_VZDirectorySharingDeviceConfiguration
```
ie the linker is still trying unconditionally to link the Monterey-only symbols.

From what I can tell, the code is correct, but there is a Swift compiler bug that is not handling the `#available` guard correctly - see eg [here](https://developer.apple.com/forums/thread/688678), [here](https://stackoverflow.com/questions/68945040/swiftui-proper-use-of-available-and-available) or [here](https://developer.apple.com/forums/thread/667659).

This PR works around this by conditionally defining an additional compile-time flag, that is checked via `#if`. This seems to work (confirmed on Big Sur and Monterey) but I don't know if there is a better workaround with less code clutter.