### PR TITLE
EFI firmware/bootloader support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-11
+    runs-on: macos-13
 
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A set of utilities to help you manage VMs with `Virtualization.framework`
 
 ### Prerequisites
 
-* macOS Big Sur (11+)
+* macOS Ventura (13+)
 * XCode.app installed
 
 ```


### PR DESCRIPTION
This requires macOS 13.0+ and does not need/use a kernel, initrd or command-line, it just boots e.g. Grub or a similar EFI bootloader from the provided disk image. A path to store the EFI variables is required.

It is a bit more awkward to use compared to more full-featured virtualisation programs like UTM, as there is no display support in vmcli for interaction with the EFI bootloader, but it is sufficient to boot Fedora 37 Cloud images and should be usable with most other images assuming they don't require user interaction with the bootloader.